### PR TITLE
feat: add tests workflow

### DIFF
--- a/.github/workflows/gradle_tests.yaml
+++ b/.github/workflows/gradle_tests.yaml
@@ -21,7 +21,7 @@ jobs:
           GRADLE_DIR: './Source' # Modify this to whereever './gradlew' is 
 
       - name: Post to Slack # Notify the channel specified in the env variables
-        if: always() && github.ref == 'refs/heads/feat/github_workflow' # Always run when on main
+        if: always() && github.ref == 'refs/heads/main' # Always run when on main
         uses: rtCamp/action-slack-notify@v2.1.3
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_TEST }} # Same bot used for all, don't change


### PR DESCRIPTION
This PR adds a workflow that runs the `gradlew` wrapper's defined tests, and posts the outcome of the tests to the specified channel (defaults to #bot-testing if invalid) if the branch the workflow was run on was `main`. 

- Add new workflow to .github/workflows folder
-  Created .github/workflows folder to allow further workflows to be written