### PR TITLE
fix: slack formatting fix

### DIFF
--- a/.github/workflows/gradle_tests.yaml
+++ b/.github/workflows/gradle_tests.yaml
@@ -21,7 +21,7 @@ jobs:
           GRADLE_DIR: './Source' # Modify this to whereever './gradlew' is 
 
       - name: Post to Slack # Notify the channel specified in the env variables
-        if: always() && github.ref == 'refs/heads/fix/slack_formatting' # Always run when on main
+        if: always() && github.ref == 'refs/heads/main' # Always run when on main
         uses: rtCamp/action-slack-notify@v2.1.3
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_TEST }} # Same bot used for all, don't change


### PR DESCRIPTION
Previously, if the commit message had any newlines, the slack formatting displaying the commit message would be broken. This PR fixes this, by encasing the commit message in block quotes instead of single quotes.